### PR TITLE
[feature] add list view for paper cards

### DIFF
--- a/plugin/src/web/components/PaperCard.vue
+++ b/plugin/src/web/components/PaperCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="paper-card-wrapper">
-    <NuxtLink :to="`/papers/${paper.slug}`" class="paper-card">
+  <div class="paper-card-wrapper" :class="{ 'paper-card-wrapper--list': viewMode === 'list' }">
+    <NuxtLink :to="`/papers/${paper.slug}`" class="paper-card" :class="{ 'paper-card--list': viewMode === 'list' }">
       <h3>{{ paper.title }}</h3>
       <p class="authors">{{ paper.authors.join(', ') }}</p>
       <p class="abstract">{{ paper.abstract }}</p>
@@ -50,6 +50,10 @@ const props = defineProps({
   paper: {
     type: Object as () => Paper,
     required: true
+  },
+  viewMode: {
+    type: String as () => 'grid' | 'list',
+    default: 'grid'
   }
 })
 
@@ -66,6 +70,10 @@ const getRepoName = (url) => {
   position: relative;
 }
 
+.paper-card-wrapper--list .edit-tags-button {
+  opacity: 1;
+}
+
 .paper-card {
   display: block;
   border: 1px solid #e2e8f0;
@@ -76,6 +84,10 @@ const getRepoName = (url) => {
   text-decoration: none;
   color: inherit;
   cursor: pointer;
+}
+
+.paper-card--list {
+  padding: 1.125rem 1.25rem;
 }
 
 .paper-card:hover {
@@ -180,5 +192,23 @@ const getRepoName = (url) => {
 .external-icon {
   font-size: 0.75em;
   opacity: 0.7;
+}
+
+@media (min-width: 960px) {
+  .paper-card--list {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 340px);
+    column-gap: 1.25rem;
+    align-items: start;
+  }
+
+  .paper-card--list .code-links {
+    margin: 0;
+    align-self: stretch;
+  }
+
+  .paper-card--list .abstract {
+    -webkit-line-clamp: 2;
+  }
 }
 </style>

--- a/plugin/src/web/components/PaperCard.vue
+++ b/plugin/src/web/components/PaperCard.vue
@@ -1,36 +1,75 @@
 <template>
   <div class="paper-card-wrapper" :class="{ 'paper-card-wrapper--list': viewMode === 'list' }">
     <NuxtLink :to="`/papers/${paper.slug}`" class="paper-card" :class="{ 'paper-card--list': viewMode === 'list' }">
-      <h3>{{ paper.title }}</h3>
-      <p class="authors">{{ paper.authors.join(', ') }}</p>
-      <p class="abstract">{{ paper.abstract }}</p>
+      <template v-if="viewMode === 'list'">
+        <div class="paper-card__list-main">
+          <h3>{{ paper.title }}</h3>
+          <p class="abstract">{{ paper.abstract }}</p>
 
-      <div v-if="paper.tags && paper.tags.length > 0" class="tags-section">
-        <TagBadge
-          v-for="tag in paper.tags"
-          :key="tag"
-          :tag="tag"
-          size="small"
-        />
-      </div>
+          <div v-if="paper.githubLinks?.length || paper.codeLinks?.length" class="code-links">
+            <h4>Code Resources:</h4>
+            <ul>
+              <li v-for="link in paper.githubLinks" :key="link">
+                <a :href="link" target="_blank" rel="noopener noreferrer" @click.stop>
+                  {{ getRepoName(link) }}
+                  <span class="external-icon">↗</span>
+                </a>
+              </li>
+              <li v-for="link in paper.codeLinks" :key="link">
+                <a :href="link" target="_blank" rel="noopener noreferrer" @click.stop>
+                  {{ link }}
+                  <span class="external-icon">↗</span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
 
-      <div v-if="paper.githubLinks?.length || paper.codeLinks?.length" class="code-links">
-        <h4>Code Resources:</h4>
-        <ul>
-          <li v-for="link in paper.githubLinks" :key="link">
-            <a :href="link" target="_blank" rel="noopener noreferrer" @click.stop>
-              {{ getRepoName(link) }}
-              <span class="external-icon">↗</span>
-            </a>
-          </li>
-          <li v-for="link in paper.codeLinks" :key="link">
-            <a :href="link" target="_blank" rel="noopener noreferrer" @click.stop>
-              {{ link }}
-              <span class="external-icon">↗</span>
-            </a>
-          </li>
-        </ul>
-      </div>
+        <div class="paper-card__list-meta">
+          <p class="authors">{{ paper.authors.join(', ') }}</p>
+          <div v-if="paper.tags && paper.tags.length > 0" class="tags-section">
+            <TagBadge
+              v-for="tag in paper.tags"
+              :key="tag"
+              :tag="tag"
+              size="small"
+            />
+          </div>
+        </div>
+      </template>
+
+      <template v-else>
+        <h3>{{ paper.title }}</h3>
+        <p class="authors">{{ paper.authors.join(', ') }}</p>
+        <p class="abstract">{{ paper.abstract }}</p>
+
+        <div v-if="paper.tags && paper.tags.length > 0" class="tags-section">
+          <TagBadge
+            v-for="tag in paper.tags"
+            :key="tag"
+            :tag="tag"
+            size="small"
+          />
+        </div>
+
+        <div v-if="paper.githubLinks?.length || paper.codeLinks?.length" class="code-links">
+          <h4>Code Resources:</h4>
+          <ul>
+            <li v-for="link in paper.githubLinks" :key="link">
+              <a :href="link" target="_blank" rel="noopener noreferrer" @click.stop>
+                {{ getRepoName(link) }}
+                <span class="external-icon">↗</span>
+              </a>
+            </li>
+            <li v-for="link in paper.codeLinks" :key="link">
+              <a :href="link" target="_blank" rel="noopener noreferrer" @click.stop>
+                {{ link }}
+                <span class="external-icon">↗</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </template>
     </NuxtLink>
     <button
       class="edit-tags-button"
@@ -68,10 +107,6 @@ const getRepoName = (url) => {
 <style scoped>
 .paper-card-wrapper {
   position: relative;
-}
-
-.paper-card-wrapper--list .edit-tags-button {
-  opacity: 1;
 }
 
 .paper-card {
@@ -202,13 +237,48 @@ const getRepoName = (url) => {
     align-items: start;
   }
 
-  .paper-card--list .code-links {
+  .paper-card__list-main {
+    min-width: 0;
+  }
+
+  .paper-card__list-meta {
+    min-width: 0;
+  }
+
+  .paper-card--list .authors {
+    margin: 0 0 0.5rem 0;
+  }
+
+  .paper-card--list .tags-section {
     margin: 0;
-    align-self: stretch;
   }
 
   .paper-card--list .abstract {
+    margin: 0.375rem 0 0 0;
     -webkit-line-clamp: 2;
+  }
+
+  .paper-card--list .code-links {
+    margin: 0.5rem 0 0 0;
+    padding: 0.625rem 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .paper-card--list .code-links h4 {
+    margin: 0;
+    white-space: nowrap;
+  }
+
+  .paper-card--list .code-links ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+  }
+
+  .paper-card--list .code-links li {
+    margin: 0;
   }
 }
 </style>

--- a/plugin/src/web/components/SearchFilterBar.vue
+++ b/plugin/src/web/components/SearchFilterBar.vue
@@ -267,7 +267,7 @@ const setViewMode = (mode: 'grid' | 'list') => {
 }
 
 .search-filter-bar__view-btn--active {
-  background: #111827;
+  background: #4b5563;
   color: #ffffff;
 }
 

--- a/plugin/src/web/components/SearchFilterBar.vue
+++ b/plugin/src/web/components/SearchFilterBar.vue
@@ -34,6 +34,25 @@
       </div>
 
       <div class="search-filter-bar__controls">
+        <div class="search-filter-bar__view-toggle" role="group" aria-label="View mode">
+          <button
+            class="search-filter-bar__view-btn"
+            :class="{ 'search-filter-bar__view-btn--active': viewMode === 'grid' }"
+            @click="setViewMode('grid')"
+            type="button"
+          >
+            Grid
+          </button>
+          <button
+            class="search-filter-bar__view-btn"
+            :class="{ 'search-filter-bar__view-btn--active': viewMode === 'list' }"
+            @click="setViewMode('list')"
+            type="button"
+          >
+            List
+          </button>
+        </div>
+
         <div class="search-filter-bar__sort">
           <label for="sort-select" class="search-filter-bar__label">Sort:</label>
           <select
@@ -64,12 +83,14 @@
 <script setup lang="ts">
 interface Props {
   availableTags: string[]
+  viewMode: 'grid' | 'list'
 }
 
 interface Emits {
   (e: 'search', query: string): void
   (e: 'filter', tags: string[]): void
   (e: 'sort', sortBy: string): void
+  (e: 'view', viewMode: 'grid' | 'list'): void
 }
 
 const props = defineProps<Props>()
@@ -121,6 +142,10 @@ const clearAll = () => {
   emit('search', '')
   emit('filter', [])
   emit('sort', 'default')
+}
+
+const setViewMode = (mode: 'grid' | 'list') => {
+  emit('view', mode)
 }
 </script>
 
@@ -221,6 +246,31 @@ const clearAll = () => {
   white-space: nowrap;
 }
 
+.search-filter-bar__view-toggle {
+  display: inline-flex;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  overflow: hidden;
+}
+
+.search-filter-bar__view-btn {
+  padding: 0.375rem 0.625rem;
+  border: none;
+  background: #ffffff;
+  color: #4b5563;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.search-filter-bar__view-btn + .search-filter-bar__view-btn {
+  border-left: 1px solid #d1d5db;
+}
+
+.search-filter-bar__view-btn--active {
+  background: #111827;
+  color: #ffffff;
+}
+
 .search-filter-bar__sort {
   display: flex;
   align-items: center;
@@ -259,12 +309,13 @@ const clearAll = () => {
 
 @media (max-width: 768px) {
   .search-filter-bar__row {
-    flex-direction: column;
-    align-items: stretch;
+    grid-template-columns: 1fr;
   }
 
   .search-filter-bar__controls {
     justify-content: flex-start;
+    flex-wrap: wrap;
+    white-space: normal;
   }
 }
 </style>

--- a/plugin/src/web/pages/index.vue
+++ b/plugin/src/web/pages/index.vue
@@ -16,9 +16,11 @@
       <SearchFilterBar
         v-if="!loading && !error && papers.length > 0"
         :available-tags="availableTags"
+        :view-mode="viewMode"
         @search="handleSearch"
         @filter="handleFilter"
         @sort="handleSort"
+        @view="handleViewChange"
       />
 
       <div v-if="loading" class="loading-state">
@@ -32,11 +34,12 @@
       <div v-else-if="displayedPapers.length === 0" class="empty-state">
         <p>No papers match your filters.</p>
       </div>
-      <div v-else class="papers-grid">
+      <div v-else :class="viewMode === 'grid' ? 'papers-grid' : 'papers-list'">
         <PaperCard
           v-for="paper in displayedPapers"
           :key="paper.slug"
           :paper="paper"
+          :view-mode="viewMode"
           @edit-tags="openTagEditor(paper)"
         />
       </div>
@@ -61,6 +64,7 @@ const { papers, loading, error, loadPapers, updatePaperTags } = usePapers()
 const searchQuery = ref('')
 const selectedTags = ref<string[]>([])
 const sortBy = ref('default')
+const viewMode = ref<'grid' | 'list'>('grid')
 const editingPaper = ref<Paper | null>(null)
 const tagSaveError = ref<string | null>(null)
 
@@ -124,6 +128,10 @@ const handleFilter = (tags: string[]) => {
 
 const handleSort = (sort: string) => {
   sortBy.value = sort
+}
+
+const handleViewChange = (mode: 'grid' | 'list') => {
+  viewMode.value = mode
 }
 
 const openTagEditor = (paper: Paper) => {
@@ -236,6 +244,13 @@ h1 {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
   gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.papers-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   margin-top: 2rem;
 }
 


### PR DESCRIPTION
## summary
- add grid/list toggle in search filter bar
- add list view rendering path for paper cards
- refine list card spacing, code resources row layout, and hover behavior for edit tags
- tune active view button color to deep gray

## commits
- ac5dbd5 [fix] compact list cards and refine view toggle style
- cb04f57 [feature] add grid and list paper card views

## testing
- npm run dev